### PR TITLE
Update PLStreamingViewManager.java

### DIFF
--- a/android/pili-react-native/src/main/java/com/qiniu/pili/droid/rnpili/PLStreamingViewManager.java
+++ b/android/pili-react-native/src/main/java/com/qiniu/pili/droid/rnpili/PLStreamingViewManager.java
@@ -105,10 +105,14 @@ public class PLStreamingViewManager extends SimpleViewManager<CameraPreviewFrame
         mReactContext = reactContext;
         mEventEmitter = mReactContext.getJSModule(RCTEventEmitter.class);
 
-        mCameraPreviewFrameView = new CameraPreviewFrameView(mReactContext);
-        mCameraPreviewFrameView.setListener(this);
-        mCameraPreviewFrameView.setLayoutParams(
-                new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+         Log.i(TAG, "mCameraPreviewFrameView："+(mCameraPreviewFrameView==null));
+if(mCameraPreviewFrameView==null){
+    mCameraPreviewFrameView = new CameraPreviewFrameView(mReactContext);
+    mCameraPreviewFrameView.setListener(this);
+    mCameraPreviewFrameView.setLayoutParams(
+            new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+}
         mReactContext.addLifecycleEventListener(this);
         return mCameraPreviewFrameView;
     }


### PR DESCRIPTION
因为view每次启动，都会重新调用createViewInstance，但是因为mCameraPreviewFrameView的问题，导致一旦stop或者页面切换之后，再次调用都会失败，所以加一个判断，可以解决重开页面调用白屏的问题。
---------以下是七牛技术支持的回复--------
组件是和 view 绑定的，但是退后台每次回来会执行 createViewInstance，但是没有走 onDropViewInstance，所以会重复创建一个 view 的界面出来，设置 singleTop 之后就不会执行 createViewInstance 了，便可以保证操作的唯一性。